### PR TITLE
Fixed <kbd> tag text color issue

### DIFF
--- a/dracula.css
+++ b/dracula.css
@@ -344,6 +344,12 @@ var {
   padding: 2px 5px;
 }
 
+kbd {
+  color: #fff;
+  box-shadow: inset 0 -1px 0 rgba(0,0,0,.25);
+  font-size: 90%;
+}
+
 table {
   max-width: 100%;
   width: 100%;


### PR DESCRIPTION
While using Dracula theme in Typora, I got following result for `<kbd>Ctrl</kbd>`

![image](https://user-images.githubusercontent.com/17901680/123071913-a6bb6e80-d447-11eb-8f75-8303593d25a9.png)

Both text color and background color are black, which makes the text "invisible".

After this fix, it looks like this:

![image](https://user-images.githubusercontent.com/17901680/123094517-8bf4f400-d45f-11eb-9fbe-2299da8cffaa.png)
